### PR TITLE
Bump minimum TLS to 1.2

### DIFF
--- a/smtp.go
+++ b/smtp.go
@@ -148,7 +148,7 @@ func (d *Dialer) Dial() (SendCloser, error) {
 
 func (d *Dialer) tlsConfig() *tls.Config {
 	if d.TLSConfig == nil {
-		return &tls.Config{ServerName: d.Host}
+		return &tls.Config{ServerName: d.Host, MinVersion: tls.VersionTLS12}
 	}
 	return d.TLSConfig
 }


### PR DESCRIPTION
Fixes CWE-295 vulnerability
As reported by golangci: G402: TLS MinVersion too low.