### PR TITLE
Bump golangci version to 1.32

### DIFF
--- a/bin/style
+++ b/bin/style
@@ -8,7 +8,7 @@ class Style
   class << self
     INSTALLER_URL = 'https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh'
     EXECUTABLE = 'golangci-lint'
-    VERSION = '1.23.6'
+    VERSION = '1.32.0'
     VERSION_TAG = "v#{VERSION}"
 
     def call
@@ -19,7 +19,8 @@ class Style
     private
 
     def install_path
-      File.join(ENV.fetch('GOPATH', ENV.fetch('HOME')), 'bin')
+      gopath = ENV.fetch('GOPATH', ENV.fetch('HOME')).split(':').first
+      File.join(gopath, 'bin')
     end
 
     def bin_path

--- a/message_test.go
+++ b/message_test.go
@@ -712,7 +712,7 @@ func stubSendMail(t *testing.T, bCount int, want *message) SendFunc {
 		if bCount > 0 {
 			boundaries := getBoundaries(t, bCount, got)
 			for i, b := range boundaries {
-				wantMsg = strings.Replace(wantMsg, "_BOUNDARY_"+strconv.Itoa(i+1)+"_", b, -1)
+				wantMsg = strings.ReplaceAll(wantMsg, "_BOUNDARY_"+strconv.Itoa(i+1)+"_", b)
 			}
 		}
 


### PR DESCRIPTION
- Update `bin/style` to fix a bug in `GOPATH` detection
- Use strings.ReplaceAll method in `strings.Replace (gocritic)