### PR TITLE
Set connection deadline before using it

### DIFF
--- a/smtp.go
+++ b/smtp.go
@@ -88,13 +88,13 @@ func (d *Dialer) Dial() (SendCloser, error) {
 		conn = tlsClient(conn, d.tlsConfig())
 	}
 
+	if d.Timeout > 0 {
+		conn.SetDeadline(time.Now().Add(d.Timeout))
+	}
+
 	c, err := smtpNewClient(conn, d.Host)
 	if err != nil {
 		return nil, err
-	}
-
-	if d.Timeout > 0 {
-		conn.SetDeadline(time.Now().Add(d.Timeout))
 	}
 
 	if d.LocalName != "" {


### PR DESCRIPTION
Creating a `smtp.Client` is actually reading from the connection (`net.Conn`). So, setting the connection deadline should be done *before* creating the `smtp.Client`.